### PR TITLE
Clarify more things about what works inside `qt{}` strings

### DIFF
--- a/rfcs/rfc0019.md
+++ b/rfcs/rfc0019.md
@@ -70,6 +70,13 @@ will be equivalent to
 qq{A ${ \scalar(TEXT) } B};
 ```
 
+The characters `$` and `@` are *not* special immediately inside a `qt{}`
+string; they are interpreted literally as per `q()` rules.
+
+```
+qt{This $is $literal, as is @this}
+```
+
 To provide a heredoc version of qt, this:
 
 ```

--- a/rfcs/rfc0019.md
+++ b/rfcs/rfc0019.md
@@ -77,6 +77,18 @@ string; they are interpreted literally as per `q()` rules.
 qt{This $is $literal, as is @this}
 ```
 
+As well as `\{`, the remaining backslash-escaped sequences that stand for
+other characters are recognised as if they appeared in a `qq()` string:
+
+```
+qt{Linefeed\n}
+qt{Escape byte - \e or \x1b or \033}
+qt{Unicode snowman \x{2603} or \N{U+2603}}
+```
+
+The case-changing or quotemeta escapes (`\l`, `\L`, `\u`, `\U`, `\F`, `\Q`,
+`\E`) are not allowed.
+
 To provide a heredoc version of qt, this:
 
 ```


### PR DESCRIPTION
The original text did not explicitly mention that regular `$foo` interpolation does not work here, but it seemed implied so I've added some words.

I've also added a guess at some words to try to clarify what to do with `\x`-style escapes. I think people would get upset if they couldn't at least have `\n` for a linefeed, so by extension I suspect any of the escapes that just stand in for some other literal character would be fine. The only problem ones are the case/quotmeta ones, so I've explicitly disallowed those.