### PR TITLE
ppc0013: Use `List::Util` for `reduce`

### DIFF
--- a/ppcs/ppc0013-overload-join-and-substr.md
+++ b/ppcs/ppc0013-overload-join-and-substr.md
@@ -9,7 +9,7 @@
 
 ## Abstract
 
-As of Perl version 5.34, `overload` is incomplete and surprising for
+As of Perl version 5.38, `overload` is incomplete and surprising for
 string operations:
 
 * the `join` builtin should be using the `concat` (`.`) overload
@@ -98,11 +98,14 @@ We do not yet foresee security issues. Guidance is welcome.
 For `join`:
 
 ```perl
-# when @list contains elements with concat overloading,
-# we expect this code:
+# When @list contains elements with concat overloading, we expect this code:
+
 my $ret = join $sep, @list;
 
-# to behave like this code:
+# To behave like this code:
+
+use List::Util 'reduce';
+
 my $ret = reduce { ( $a . $sep ) . $b } @list;
 ```
 


### PR DESCRIPTION
It also fixes GitHub's Markdown's
highlighting the Perl code correctly

*it seems if there's # (comments) above
the code it fails to recognize ```perl*

Bump 5.34 to 5.38 since there's still
significant progress in this field until now