### PR TITLE
doc: be explicit about the short-circuiting behavior

### DIFF
--- a/ppcs/ppc0021-optional-chaining-operator.md
+++ b/ppcs/ppc0021-optional-chaining-operator.md
@@ -100,6 +100,25 @@ is equivalent to:
 
 with the important caveat that EXPR1 is only evaluated once.
 
+When used in a longer chain of dereferences, an undef value will short-circuit the entire
+chain, rather than just a single expression:
+
+   EXPR1 ?-> EXPR2 ?-> EXPR3
+
+is equivalent to:
+
+```perl
+    if (defined EXPR1) {
+      if (defined EXPR1->EXPR2) {
+        return EXPR1->EXPR2->EXPR3
+      } else {
+        return ()
+      }
+    } else {
+      return () # empty list
+    }
+```
+
 ## Backwards Compatibility
 
 All code with `?->` currently yields a compile time syntax error, so there

--- a/ppcs/ppc0021-optional-chaining-operator.md
+++ b/ppcs/ppc0021-optional-chaining-operator.md
@@ -188,6 +188,9 @@ Expected common uses:
 
     # my $class = 'SomeClass'; $class->new if defined $class;
     my $class = 'SomeClass'; $class?->new;
+
+    # defined $aref ? $aref->[0] = 9001 : ()
+    $aref?->[0] = 9001; # $aref remains undef in the undef case
 ```
 
 Unusual and edge cases, for comprehension:

--- a/ppcs/ppc0021-optional-chaining-operator.md
+++ b/ppcs/ppc0021-optional-chaining-operator.md
@@ -188,12 +188,6 @@ Expected common uses:
 
     # my $class = 'SomeClass'; $class->new if defined $class;
     my $class = 'SomeClass'; $class?->new;
-
-    # my $obj = %SomeClass:: ? SomeClass->new : ();
-    my $obj = SomeClass?->new;  # TBD: see 'Future Scope' below.
-
-    # my @objs = (%NotValid:: ? NotValid->new : (), %Valid:: ? Valid->new : ());
-    my @objs = ( NotValid?->new, Valid?->new ); # @objs == ( ValidObject )
 ```
 
 Unusual and edge cases, for comprehension:


### PR DESCRIPTION
While implementing this PPC, i realized that it didn't explicitly discuss what the
short-circuiting behavior actually entails in a longer chain. I assume the intention is
what I've added here, but we can discuss now if I was wrong in understanding.

I have also added in an explicit lvalue case, b/c as far as i understood, the intention here is to allow assigning into the expression in the non-undef case.

I also touched up the doc, removing the bareword example from the example section (b/c it's NOT included).
