### PR TITLE
Clarifications on PPC0027

### DIFF
--- a/ppcs/ppc0027-any-and-all.md
+++ b/ppcs/ppc0027-any-and-all.md
@@ -116,6 +116,8 @@ In any case, as junctions behave like values, they do not require special syntax
 
 ## Open Issues
 
+* A little-used behaviour of `grep` and `map` is that the `$_` variable does not merely store a copy of each original list element but actually aliases it. This is almost never used intentionally and can often lead to accidentally modifying the original list values, leading to subtle data corruption bugs. As these proposed operators are new, there will be no compatibility issues in changing the behaviour here to say that they are copies, not aliases. Perhaps they should even be read-only copies.
+
 ## Copyright
 
 Copyright (C) 2024, Paul Evans.

--- a/ppcs/ppc0027-any-and-all.md
+++ b/ppcs/ppc0027-any-and-all.md
@@ -19,9 +19,11 @@ Most code of any appreciable size tends to make use of at least the `any` or `al
 
 ## Specification
 
-New named features that, when enabled, activate syntax analogous to the existing `grep` operator, named `any` and `all`:
+A new named feature that, when enabled, activates new operators analogous to the existing `grep` operator, named `any` and `all`:
 
 ```perl
+use feature 'list_utils';
+
 any { BLOCK } LIST
 
 all { BLOCK } LIST
@@ -50,9 +52,9 @@ Some::Class->new(
 
 ## Backwards Compatibility
 
-As these new operators are guarded by named features, there are no immediate concerns with backward compatiblity in the short-term.
+As these new operators are guarded by a named feature, there are no immediate concerns with backward compatiblity in the short-term.
 
-In the longer term, if these named features become part of a versioned feature bundle that is enabled by a corresponding `use VERSION` declaration there may be concerns that the names collide with functions provided by `List::Util` or similar modules. As the intention of these operators is to provide the same behaviour, this is not considered a major problem. Differences due to caller scope as outlined above may be surprising to a small number of users.
+In the longer term, if this named feature becomes part of a versioned feature bundle that is enabled by a corresponding `use VERSION` declaration there may be concerns that the names collide with functions provided by `List::Util` or similar modules. As the intention of these operators is to provide the same behaviour, this is not considered a major problem. Differences due to caller scope as outlined above may be surprising to a small number of users.
 
 ## Security Implications
 
@@ -60,7 +62,7 @@ In the longer term, if these named features become part of a versioned feature b
 
 ```perl
 use v5.40;
-use feature 'any';
+use feature 'list_utils';
 
 if( any { $_ > 10 } 5, 10, 15, 20 ) { say "A number above 10" }
 ```
@@ -113,10 +115,6 @@ if( $x is Any( things... ) ) { ... }
 In any case, as junctions behave like values, they do not require special syntax like the block-invoking keywords proposed here, so they can be provided by regular function-call syntax from regular modules.
 
 ## Open Issues
-
-* There could be anything up to five new operators added by this idea. Do they all get their own named feature flags? Do they all live under one flag?
-
-* Should the flag be called `any`? That might be confusing as compared to the `:any` import tag which would request all features.
 
 ## Copyright
 


### PR DESCRIPTION
Closes the existing "open issues" with regard to naming of the feature flag.

Also opens one new issue to do with aliasing vs. copy of `$_`.