### PR TITLE
update the PPC status to be more consistent

### DIFF
--- a/ppcs/ppc0001-n-at-a-time-for.md
+++ b/ppcs/ppc0001-n-at-a-time-for.md
@@ -5,7 +5,7 @@
     Author:
     Sponsor: Nicholas Clark <nick@ccl4.org>
     ID:      0001
-    Status:  Implemented
+    Status:  Incorporated
 
 ## Abstract
 

--- a/ppcs/ppc0004-defer-block.md
+++ b/ppcs/ppc0004-defer-block.md
@@ -5,7 +5,7 @@
     Author:  Paul Evans <PEVANS>
     Sponsor:
     ID:      0004
-    Status:  Implemented
+    Status:  Incorporated
 
 ## Abstract
 

--- a/ppcs/ppc0006-load-module.md
+++ b/ppcs/ppc0006-load-module.md
@@ -5,7 +5,7 @@
     Author:  Ricardo Signes <rjbs@semiotic.systems>
     Sponsor: Ricardo Signes <rjbs@semiotic.systems>
     ID:      0006
-    Status:  Implemented
+    Status:  Incorporated
 
 ## Abstract
 

--- a/ppcs/ppc0007-source-encoding.md
+++ b/ppcs/ppc0007-source-encoding.md
@@ -5,7 +5,7 @@
     Author:  Ricardo Signes <rjbs@semiotic.systems>
     Sponsor: Ricardo Signes <rjbs@semiotic.systems>
     ID:      0007
-    Status:  Draft
+    Status:  Proposed
 
 ## Abstract
 

--- a/ppcs/ppc0008-sv-boolean-type.md
+++ b/ppcs/ppc0008-sv-boolean-type.md
@@ -5,7 +5,7 @@
     Author:  Paul Evans <PEVANS>
     Sponsor:
     ID:      0008
-    Status:  Implemented
+    Status:  Incorporated
 
 ## Abstract
 

--- a/ppcs/ppc0009-builtin-namespace.md
+++ b/ppcs/ppc0009-builtin-namespace.md
@@ -5,7 +5,7 @@
     Author:  Paul Evans <PEVANS>
     Sponsor:
     ID:      0009
-    Status:  Implemented
+    Status:  Incorporated
 
 ## Abstract
 

--- a/ppcs/ppc0011-slurp-argument.md
+++ b/ppcs/ppc0011-slurp-argument.md
@@ -2,10 +2,10 @@
 
 ## Preamble
 
-    Author: Tomasz Konojacki <me@xenu.pl>
+    Author:  Tomasz Konojacki <me@xenu.pl>
     Sponsor:
     ID: 0011
-    Status: Implemented
+    Status:  Incorporated
 
 ## Abstract
 

--- a/ppcs/ppc0012-configure-no-taint.md
+++ b/ppcs/ppc0012-configure-no-taint.md
@@ -5,7 +5,7 @@
     Author:  Neil Bowers <neilb@cpan.org>
     Sponsor:
     ID:      0012
-    Status:  Accepted
+    Status:  Wanted
 
 
 ## Abstract

--- a/ppcs/ppc0013-overload-join-and-substr.md
+++ b/ppcs/ppc0013-overload-join-and-substr.md
@@ -5,7 +5,7 @@
     Authors: Eric Herman <eric@freesa.org>, Philippe Bruhat <book@cpan.org>
     Sponsor: Paul Evans <leonerd@leonerd.org.uk>
     ID:      0013
-    Status:  Accepted
+    Status:  Wanted
 
 ## Abstract
 

--- a/ppcs/ppc0014-english-aliases.md
+++ b/ppcs/ppc0014-english-aliases.md
@@ -4,7 +4,7 @@
 
     Author:  Graham Knop <haarg@haarg.org>
     ID:      0014
-    Status:  Draft
+    Status:  Proposed
 
 ## Abstract
 

--- a/ppcs/ppc0015-drop-old-package-separator.md
+++ b/ppcs/ppc0015-drop-old-package-separator.md
@@ -5,7 +5,7 @@
     Author:  Nicolás Mendoza <mendoza@pvv.ntnu.no>
     Sponsor:
     ID:      0015
-    Status:  Draft
+    Status:  Proposed
 
 ## Abstract
 

--- a/ppcs/ppc0016-indexed-builtin.md
+++ b/ppcs/ppc0016-indexed-builtin.md
@@ -5,7 +5,7 @@
     Author:  Ricardo Signes <rjbs@semiotic.systems>
     Sponsor:
     ID:      0016
-    Status:  Implemented
+    Status:  Incorporated
 
 ## Abstract
 

--- a/ppcs/ppc0017-original-build-type.md
+++ b/ppcs/ppc0017-original-build-type.md
@@ -5,7 +5,7 @@
     Author:  Graham Knop <haarg@haarg.org>
     Sponsor:
     ID:      0017
-    Status:  Implemented
+    Status:  Incorporated
 
 ## Abstract
 

--- a/ppcs/ppc0018-module-true.md
+++ b/ppcs/ppc0018-module-true.md
@@ -5,7 +5,7 @@
     Author:  Curtis "Ovid" Poe <curtis.poe@gmail.com>
     Sponsor:
     ID:      0018
-    Status:  Implemented
+    Status:  Incorporated
 
 ## Abstract
 

--- a/ppcs/ppc0019-qt-string.md
+++ b/ppcs/ppc0019-qt-string.md
@@ -5,7 +5,7 @@
     Author:  Ricardo Signes <rjbs@semiotic.systems>
     Sponsor: RJBS
     ID:      0019
-    Status:  Draft
+    Status:  Proposed
 
 ## Abstract
 

--- a/ppcs/ppc0020-lexical-export.md
+++ b/ppcs/ppc0020-lexical-export.md
@@ -5,7 +5,7 @@
     Author:  Paul Evans <PEVANS>
     Sponsor:
     ID:      0020
-    Status:  Implemented
+    Status:  Incorporated
 
 ## Abstract
 

--- a/ppcs/ppc0021-optional-chaining-operator.md
+++ b/ppcs/ppc0021-optional-chaining-operator.md
@@ -5,7 +5,7 @@
     Author:  Breno G. de Oliveira <garu@cpan.org>
     Sponsor:
     ID:      0021
-    Status:  Draft
+    Status:  Proposed
 
 ## Abstract
 

--- a/ppcs/ppc0022-metaprogramming.md
+++ b/ppcs/ppc0022-metaprogramming.md
@@ -5,7 +5,7 @@
     Author:  Paul Evans <PEVANS>
     Sponsor:
     ID:      0022
-    Status:  Exploratory
+    Status:  Proposed
 
 ## Abstract
 

--- a/ppcs/ppc0023-map-grep-with-topic.md
+++ b/ppcs/ppc0023-map-grep-with-topic.md
@@ -2,9 +2,9 @@
 
 ## Preamble
 
-    Author:     Graham Knop <haarg@haarg.org>
-    ID:         0023
-    Status:     Exploratory
+    Author:  Graham Knop <haarg@haarg.org>
+    ID:      0023
+    Status:  Proposed
 
 ## Abstract
 

--- a/ppcs/ppc0024-signature-named-parameters.md
+++ b/ppcs/ppc0024-signature-named-parameters.md
@@ -5,7 +5,7 @@
     Author:  Paul Evans <PEVANS>
     Sponsor:
     ID:      0024
-    Status:  Exploratory
+    Status:  Proposed
 
 ## Abstract
 

--- a/ppcs/ppc0025-perl-version.md
+++ b/ppcs/ppc0025-perl-version.md
@@ -4,7 +4,7 @@
 
     Author:  Aristotle Pagaltzis <pagaltzis@gmx.de>
     ID:      0025
-    Status:  Draft
+    Status:  Proposed
 
 ## Abstract
 

--- a/ppcs/ppc0026-enhanced-regex-xx.md
+++ b/ppcs/ppc0026-enhanced-regex-xx.md
@@ -4,7 +4,7 @@
 
     Author:  Karl Williamson <khw@cpan.org>
     ID:      0026
-    Status:  Draft
+    Status:  Proposed
 
 ## Abstract
 

--- a/ppcs/ppc0027-any-and-all.md
+++ b/ppcs/ppc0027-any-and-all.md
@@ -5,7 +5,7 @@
     Author:  Paul Evans <PEVANS>
     Sponsor: 
     ID:      0027
-    Status:  Exploratory
+    Status:  Proposed
 
 ## Abstract
 

--- a/ppcs/ppc0028-custom-prefix-postfix-operators.md
+++ b/ppcs/ppc0028-custom-prefix-postfix-operators.md
@@ -5,7 +5,7 @@
     Author:  Paul Evans <PEVANS>
     Sponsor:
     ID:      0028
-    Status:  Exploratory
+    Status:  Proposed
 
 ## Abstract
 

--- a/ppcs/ppc0029-attributes-v2.md
+++ b/ppcs/ppc0029-attributes-v2.md
@@ -5,7 +5,7 @@
     Author:  Paul Evans <PEVANS>
     Sponsor:
     ID:      0029
-    Status:  Exploratory
+    Status:  Proposed
 
 ## Abstract
 

--- a/ppcs/ppc0030-undef-aware-equality.md
+++ b/ppcs/ppc0030-undef-aware-equality.md
@@ -5,7 +5,7 @@
     Author:  Paul Evans <PEVANS>
     Sponsor:
     ID:      0030
-    Status:  Exploratory
+    Status:  Proposed
 
 ## Abstract
 

--- a/ppcs/ppc0031-metaoperator-flags.md
+++ b/ppcs/ppc0031-metaoperator-flags.md
@@ -5,7 +5,7 @@
     Author:  Paul Evans <PEVANS>
     Sponsor:
     ID:      0031
-    Status:  Exploratory
+    Status:  Proposed
 
 ## Abstract
 


### PR DESCRIPTION
The different values for PPC status are somewhat inconsistent between the various documents in the docs/ directory, and the actual PPC documents.

For example, "Accepted" in the process document means "with the code merged as a new (probably experimental!) feature of perl", while in the current PPCs documents, it was used to mean "Accepted Proposal".

During PSC #178 2025-02-06, Aristotle and BooK discussed the issue, and proposed some new status names, with a goal of improving clarity.

This commit makes the following status renames:

    Draft       => Proposed
    Exploratory => Proposed
    Accepted    => Wanted
    Implemented => Incorporated

The discussion also revolved about the possible parallel existence of an idea (the PPC proposal) and an implementation. An implementation can exist while the PPC is still being discussed an evaluated, and help steer it. An implementation can be rejected, while the idea is still accepted.